### PR TITLE
Add a patch to run gnarl on boards without OLED module

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,9 @@ and may be subject to rebasing without notice.
 This project has been developed and tested on
 a TTGO version 1 ESP32 868/915 MHz LoRa OLED module,
 which contains an ESP32 SoC, an RFM95 LoRa radio,
-a 128x64 pixel SSD1306 OLED display, and a LiPo battery charger.
+a 128x64 pixel SSD1306 OLED display, and a LiPo battery charger. The
+version without OLED display is supported as well (see below in Software
+setup).
 
 The module has two push-buttons.
 One is hard-wired to reset the board;
@@ -83,6 +85,13 @@ git submodule status --recursive
 
 1. Run `docker pull espressif/idf:release-v4.1` to download the ESP-IDF image.
 [See this page for additional information.](https://docs.espressif.com/projects/esp-idf/en/release-v4.1/api-guides/tools/idf-docker-image.html)
+
+## Disable OLED support if necessary
+
+OLED use is defined in`include/module.h` and must be commented out if no OLED is available.
+Just add two slashes in front of the statement.
+
+	// #define OLED_ENABLE
 
 ## Building GNARL
 

--- a/include/module.h
+++ b/include/module.h
@@ -3,6 +3,8 @@
 #define BUTTON		GPIO_NUM_0
 #define LED		GPIO_NUM_2
 
+// Comment out the following line for a TTGO ESP LoRa v1 module w/o OLED
+#define OLED_ENABLE
 #define OLED_SDA	GPIO_NUM_4
 #define OLED_SCL	GPIO_NUM_15
 #define OLED_RST	GPIO_NUM_16
@@ -13,3 +15,4 @@
 #define LORA_CS		GPIO_NUM_18
 #define LORA_RST	GPIO_NUM_14
 #define LORA_IRQ	GPIO_NUM_26
+

--- a/lib/oled/oled.c
+++ b/lib/oled/oled.c
@@ -1,3 +1,5 @@
+#ifdef OLED_ENABLE
+
 #include <u8g2.h>
 
 static u8g2_t u8g2;
@@ -140,3 +142,36 @@ void oled_init(void) {
 	oled_on();
 	oled_clear();
 }
+
+#else
+
+void oled_init() {}
+
+void oled_on() {}
+void oled_off() {}
+
+void oled_clear() {}
+void oled_update() {}
+
+int oled_font_width() { return 1; }
+int oled_font_ascent() { return 2; }
+int oled_font_descent() { return 3; }
+
+void oled_font_small() {}
+void oled_font_medium() {}
+void oled_font_large() {}
+
+void oled_font_sans_serif() {}
+void oled_font_serif() {}
+void oled_font_monospace() {}
+
+void oled_align_left() {}
+void oled_align_right() {}
+void oled_align_center() {}
+void oled_align_center_both() {}
+
+int oled_string_width(const char *s) { return 4; }
+void oled_draw_string(int x, int y, const char *s) {}
+
+void oled_draw_box(int x, int y, int w, int h) {}
+#endif


### PR DESCRIPTION
In particular [this module](https://www.banggood.com/LILYGO-2Pcs-TTGO-ESP32-SX1276-LoRa-868MHz-bluetooth-WI-FI-Lora-Internet-Antenna-Development-Board-p-1295045.html)

Otherwise it will hang randomly.