### PR TITLE
Make communication with 754/554 pump and Loop more reliable

### DIFF
--- a/lib/radio/rfm95.c
+++ b/lib/radio/rfm95.c
@@ -339,6 +339,8 @@ static void wait_until_interrupt(int timeout) {
 static void wait_until_interrupt(int timeout) {
 	ESP_LOGD(TAG, "waiting until interrupt");
 	rx_waiting_task = xTaskGetCurrentTaskHandle();
+	// Clear any notifications before starting to wait.
+	xTaskNotifyWait(0, 0, 0, 0);
 	xTaskNotifyWait(0, 0, 0, pdMS_TO_TICKS(timeout));
 	rx_waiting_task = 0;
 	ESP_LOGD(TAG, "finished waiting");

--- a/src/gnarl/gnarl.c
+++ b/src/gnarl/gnarl.c
@@ -284,7 +284,7 @@ void rfspy_command(const uint8_t *buf, int count, int rssi) {
 	// It is totally fine to ignore subsequent calls as if
 	// in_get_packet is true we are already looping in the code
 	// to send a response.  The commands and responses do not
-        // seem to have a sequence number.
+	// seem to have a sequence number.
 	if ((cmd == CmdGetPacket) && in_get_packet) {
 		ESP_LOGI(TAG, "CmdGetPacket while GetPacket is active, ignoring.");
 		return;
@@ -305,7 +305,7 @@ void rfspy_command(const uint8_t *buf, int count, int rssi) {
 	};
 	memcpy(req.data, buf + 2, req.length);
 	if (!xQueueSend(request_queue, &req, 0)) {
-		ESP_LOGD(TAG, "rfspy_command: cannot queue request for command %d, queue length %d",
+		ESP_LOGE(TAG, "rfspy_command: cannot queue request for command %d, queue length %d",
                          cmd, uxQueueMessagesWaiting(request_queue));
 		return;
 	}

--- a/src/gnarl/gnarl.c
+++ b/src/gnarl/gnarl.c
@@ -39,7 +39,6 @@ static QueueHandle_t request_queue;
 
 static TaskHandle_t gnarl_loop_handle = NULL;
 
-
 typedef struct __attribute__((packed)) {
 	uint8_t listen_channel;
 	uint32_t timeout_ms;
@@ -163,7 +162,7 @@ static void get_packet(const uint8_t *buf, int len) {
 	ESP_LOGD(TAG, "get_packet: listen_channel %d timeout_ms %d",
 		 p->listen_channel, p->timeout_ms);
 	in_get_packet = 1;
-	int n = receive(rx_buf.packet, sizeof(rx_buf.packet), timeout);
+	int n = receive(rx_buf.packet, sizeof(rx_buf.packet), p->timeout_ms);
 	rx_common(n, read_rssi());
 	in_get_packet = 0;
 }

--- a/src/gnarl/gnarl.c
+++ b/src/gnarl/gnarl.c
@@ -33,9 +33,12 @@ typedef struct {
 	uint8_t data[MAX_PARAM_LEN + MAX_PACKET_LEN];
 } rfspy_request_t;
 
-#define QUEUE_LENGTH		10
+#define QUEUE_LENGTH		20
 
 static QueueHandle_t request_queue;
+
+static TaskHandle_t gnarl_loop_handle = NULL;
+
 
 typedef struct __attribute__((packed)) {
 	uint8_t listen_channel;
@@ -152,13 +155,17 @@ static void rx_common(int n, int rssi) {
 	send_bytes((uint8_t *)&rx_buf, 2 + n);
 }
 
+static volatile int in_get_packet = 0;
+
 static void get_packet(const uint8_t *buf, int len) {
 	get_packet_cmd_t *p = (get_packet_cmd_t *)buf;
 	reverse_four_bytes(&p->timeout_ms);
 	ESP_LOGD(TAG, "get_packet: listen_channel %d timeout_ms %d",
 		 p->listen_channel, p->timeout_ms);
-	int n = receive(rx_buf.packet, sizeof(rx_buf.packet), p->timeout_ms);
+	in_get_packet = 1;
+	int n = receive(rx_buf.packet, sizeof(rx_buf.packet), timeout);
 	rx_common(n, read_rssi());
+	in_get_packet = 0;
 }
 
 static void send_packet(const uint8_t *buf, int len) {
@@ -273,11 +280,24 @@ void rfspy_command(const uint8_t *buf, int count, int rssi) {
 		return;
 	}
 	rfspy_cmd_t cmd = buf[1];
-	// Special case: handle register upates immediately so they don't fill up the queue.
-	if (cmd == CmdUpdateRegister) {
-		ESP_LOGI(TAG, "CmdUpdateRegister");
-		update_register(buf + 2, count - 2);
+
+	// GetPacket is used by Loop to wait for MySentry packets
+	// It is totally fine to ignore subsequent calls as if
+	// in_get_packet is true we are already looping in the code
+	// to send a response.  The commands and responses do not
+        // seem to have a sequence number.
+	if ((cmd == CmdGetPacket) && in_get_packet) {
+		ESP_LOGI(TAG, "CmdGetPacket while GetPacket is active, ignoring.");
 		return;
+	}
+
+	// Do this before enqueueing, otherwise there is a risk of self-inflicting
+	// the notification due to concurrency.
+	if (uxQueueMessagesWaiting(request_queue) > 0) {
+		if (in_get_packet) {
+			ESP_LOGD(TAG, "rfspy_command sending notify give.");
+			xTaskNotifyGive(gnarl_loop_handle);
+		}
 	}
 	rfspy_request_t req = {
 		.command = cmd,
@@ -286,7 +306,8 @@ void rfspy_command(const uint8_t *buf, int count, int rssi) {
 	};
 	memcpy(req.data, buf + 2, req.length);
 	if (!xQueueSend(request_queue, &req, 0)) {
-		ESP_LOGE(TAG, "rfspy_command: cannot queue request for command %d", cmd);
+		ESP_LOGD(TAG, "rfspy_command: cannot queue request for command %d, queue length %d",
+                         cmd, uxQueueMessagesWaiting(request_queue));
 		return;
 	}
 	ESP_LOGD(TAG, "rfspy_command %d, queue length %d", cmd, uxQueueMessagesWaiting(request_queue));
@@ -350,5 +371,5 @@ static void gnarl_loop(void *unused) {
 void start_gnarl_task(void) {
 	request_queue = xQueueCreate(QUEUE_LENGTH, sizeof(rfspy_request_t));
 	// Start radio task with high priority to avoid receiving truncated packets.
-	xTaskCreate(gnarl_loop, "gnarl", 4096, 0, tskIDLE_PRIORITY + 24, 0);
+	xTaskCreate(gnarl_loop, "gnarl", 4096, 0, tskIDLE_PRIORITY + 24, &gnarl_loop_handle);
 }


### PR DESCRIPTION
- Interrupt active GetPacket calls
- Stop reordering register updates

This should fix issues #8 and #9 .