### PR TITLE
Add task watchdog

### DIFF
--- a/src/gnarl/gnarl.c
+++ b/src/gnarl/gnarl.c
@@ -5,6 +5,7 @@
 #include <unistd.h>
 
 #include <esp_timer.h>
+#include <esp_task_wdt.h>
 #include <freertos/FreeRTOS.h>
 #include <freertos/queue.h>
 #include <freertos/task.h>
@@ -294,12 +295,14 @@ void rfspy_command(const uint8_t *buf, int count, int rssi) {
 
 static void gnarl_loop(void *unused) {
 	ESP_LOGD(TAG, "starting gnarl_loop");
+	esp_task_wdt_add(NULL);
 	const int timeout_ms = 60*MILLISECONDS;
 	for (;;) {
 		rfspy_request_t req;
 		if (!xQueueReceive(request_queue, &req, pdMS_TO_TICKS(timeout_ms))) {
 			continue;
 		}
+		esp_task_wdt_reset();
 		switch (req.command) {
 		case CmdGetState:
 			ESP_LOGI(TAG, "CmdGetState");

--- a/src/gnarl/gnarl.h
+++ b/src/gnarl/gnarl.h
@@ -9,6 +9,8 @@
 #define MILLISECONDS	1000
 #define SECONDS		1000000
 
+#define WDT_TIMEOUT_SECONDS (5*60)
+
 #define MHz		1000000
 
 // Track github.com/ps2/rileylink/firmware/ble113_rfspy/gatt.xml

--- a/src/gnarl/main.c
+++ b/src/gnarl/main.c
@@ -3,6 +3,7 @@
 #include <stdio.h>
 
 #include <esp_wifi.h>
+#include <esp_task_wdt.h>
 
 #include "display.h"
 #include "rfm95.h"
@@ -10,6 +11,8 @@
 #define PUMP_FREQUENCY 916600000
 
 void app_main(void) {
+	ESP_LOGD(TAG, "enable watchdag with a timeout of %d seconds", WDT_TIMEOUT_SECONDS);
+	esp_task_wdt_init(WDT_TIMEOUT_SECONDS, true);
 	ESP_LOGI(TAG, "%s", SUBG_RFSPY_VERSION);
 	rfm95_init();
 	uint8_t v = read_version();


### PR DESCRIPTION
Mainly to catch any coding mistakes.  If the GNARL is not connected it will reboot every 5 minutes, but that's probably and okay frequency.